### PR TITLE
Test with modern Ruby release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
 rvm:
- - "2.2.3"
- - "2.0.0"
- - "1.9.3"
+ - "2.5.3"
 script: bundle exec rspec

--- a/lib/timetwister/utilities.rb
+++ b/lib/timetwister/utilities.rb
@@ -4,10 +4,10 @@ class Utilities
 
 	# walk through a hash and transforms all ints to strings
 	# input: a hash
-	# output: same hash, but with all Fixnums converted to strings
+	# output: same hash, but with all Integers converted to strings
 	def self.stringify_values(hash)
 		hash.each do |k,v|
-			if v.is_a?(Fixnum)
+			if v.is_a?(Integer)
 				hash[k] = v.to_s
 			end
 		end

--- a/timetwister.gemspec
+++ b/timetwister.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_runtime_dependency "chronic", "~> 0.10.2"
 end


### PR DESCRIPTION
This commit allows the build to go green again and includes a few changes:
* Simplify the test matrix by only testing Ruby 2.5.3 (for now). Needs discussion by maintainers.
* Fixnums are now Integers
* Allow bundler 1.x or 2.x