### PR TITLE
support for season ranges

### DIFF
--- a/lib/timetwister/utilities.rb
+++ b/lib/timetwister/utilities.rb
@@ -236,11 +236,7 @@ class Utilities
 		]
 
 		# transform seasons to months
-		string.gsub!(/[Ww]inter/, " January 1 - March 20 ")
-		string.gsub!(/[Ss]pring/, " March 20 - June 21 ")
-		string.gsub!(/[Ss]ummer/, " June 21 - September 23 ")
-		string.gsub!(/[Aa]utumn/, " September 23 - December 22 ")
-		string.gsub!(/[Ff]all/, " September 23 - December 22 ")
+		string = replace_seasons(string)
 
 		# remove days of the week
 		dow = [/[Ss]unday,?\s+/, /[Mm]onday,?\s+/, /[Tt]uesday,?\s+/, /[Ww]ednesday,?\s+/, /[Tt]hursday,?\s+/, /[Ff]riday,?\s+/, /[Ss]aturday,?\s+/]
@@ -255,6 +251,28 @@ class Utilities
 
 		substrings.each { |s| string.gsub!(s,'') }
 		string.strip!
+		return string
+	end
+
+	def self.replace_seasons(string)
+		seasons = {	'win[^\s]*'	=>	['January 1', 'March 20'],
+					'spr[^\s]*'	=>	['March 20', 'June 21'],
+					'sum[^\s]*'	=>	['June 21', 'September 23'],
+					'aut[^\s]*'	=>	['September 23', 'December 31'],
+					'fal[^\s]*'	=>	['September 23', 'December 31']}
+
+		# if we're working with a range, we need to be a little careful, so that we don't create sub-ranges in a string
+		is_range = string.match(/[^-]+?-[^-]+?/)
+
+		seasons.each do |season, dates|
+			regex = Regexp.new(season, Regexp::IGNORECASE)
+
+			# is the season the beginning or the end of a range?
+			new_date = (is_range ? (string.match(Regexp.new(season + '.+?-', Regexp::IGNORECASE)) ? dates[0] : dates[1]) : dates.join(' - '))
+			
+			string = string.gsub(regex, new_date)
+		end
+
 		return string
 	end
 

--- a/lib/timetwister/version.rb
+++ b/lib/timetwister/version.rb
@@ -1,3 +1,3 @@
 module Timetwister
-  VERSION = "0.2.7"
+  VERSION = "0.2.8"
 end

--- a/spec/dates_spec.rb
+++ b/spec/dates_spec.rb
@@ -344,8 +344,17 @@ describe Timetwister do
 		end
 	end
 
-	it "parses seasons" do
+	it "parses single seasons" do
 		date = Timetwister.parse("Winter 1776")
+		expect(date[0][:date_start]).to eq("1776-01-01")
+		expect(date[0][:date_start_full]).to eq("1776-01-01")
+		expect(date[0][:date_end]).to eq("1776-03-20")
+		expect(date[0][:date_end_full]).to eq("1776-03-20")
+		expect(date[0][:inclusive_range]).to eq(true)
+		expect(date[0][:index_dates]).to eq([1776])
+		expect(date[0][:test_data]).to eq("310")
+
+		date = Timetwister.parse("win. 1776")
 		expect(date[0][:date_start]).to eq("1776-01-01")
 		expect(date[0][:date_start_full]).to eq("1776-01-01")
 		expect(date[0][:date_end]).to eq("1776-03-20")
@@ -363,7 +372,25 @@ describe Timetwister do
 		expect(date[0][:index_dates]).to eq([1776])
 		expect(date[0][:test_data]).to eq("310")
 
+		date = Timetwister.parse("1776 Spr")
+		expect(date[0][:date_start]).to eq("1776-03-20")
+		expect(date[0][:date_start_full]).to eq("1776-03-20")
+		expect(date[0][:date_end]).to eq("1776-06-21")
+		expect(date[0][:date_end_full]).to eq("1776-06-21")
+		expect(date[0][:inclusive_range]).to eq(true)
+		expect(date[0][:index_dates]).to eq([1776])
+		expect(date[0][:test_data]).to eq("310")
+
 		date = Timetwister.parse("1776 Summer")
+		expect(date[0][:date_start]).to eq("1776-06-21")
+		expect(date[0][:date_start_full]).to eq("1776-06-21")
+		expect(date[0][:date_end]).to eq("1776-09-23")
+		expect(date[0][:date_end_full]).to eq("1776-09-23")
+		expect(date[0][:inclusive_range]).to eq(true)
+		expect(date[0][:index_dates]).to eq([1776])
+		expect(date[0][:test_data]).to eq("310")
+
+		date = Timetwister.parse("1776 Summ")
 		expect(date[0][:date_start]).to eq("1776-06-21")
 		expect(date[0][:date_start_full]).to eq("1776-06-21")
 		expect(date[0][:date_end]).to eq("1776-09-23")
@@ -375,11 +402,49 @@ describe Timetwister do
 		date = Timetwister.parse("Fall 1776")
 		expect(date[0][:date_start]).to eq("1776-09-23")
 		expect(date[0][:date_start_full]).to eq("1776-09-23")
-		expect(date[0][:date_end]).to eq("1776-12-22")
-		expect(date[0][:date_end_full]).to eq("1776-12-22")
+		expect(date[0][:date_end]).to eq("1776-12-31")
+		expect(date[0][:date_end_full]).to eq("1776-12-31")
 		expect(date[0][:inclusive_range]).to eq(true)
 		expect(date[0][:index_dates]).to eq([1776])
 		expect(date[0][:test_data]).to eq("310")
+
+		date = Timetwister.parse("Autumn 1776")
+		expect(date[0][:date_start]).to eq("1776-09-23")
+		expect(date[0][:date_start_full]).to eq("1776-09-23")
+		expect(date[0][:date_end]).to eq("1776-12-31")
+		expect(date[0][:date_end_full]).to eq("1776-12-31")
+		expect(date[0][:inclusive_range]).to eq(true)
+		expect(date[0][:index_dates]).to eq([1776])
+		expect(date[0][:test_data]).to eq("310")
+
+		date = Timetwister.parse("Aut. 1776")
+		expect(date[0][:date_start]).to eq("1776-09-23")
+		expect(date[0][:date_start_full]).to eq("1776-09-23")
+		expect(date[0][:date_end]).to eq("1776-12-31")
+		expect(date[0][:date_end_full]).to eq("1776-12-31")
+		expect(date[0][:inclusive_range]).to eq(true)
+		expect(date[0][:index_dates]).to eq([1776])
+		expect(date[0][:test_data]).to eq("310")
+	end
+
+	it "parses ranges of seasons" do
+		date = Timetwister.parse("Winter 1776 - Spring 1777")
+		expect(date[0][:date_start]).to eq("1776-01-01")
+		expect(date[0][:date_start_full]).to eq("1776-01-01")
+		expect(date[0][:date_end]).to eq("1777-06-21")
+		expect(date[0][:date_end_full]).to eq("1777-06-21")
+		expect(date[0][:inclusive_range]).to eq(true)
+		expect(date[0][:index_dates]).to eq([1776, 1777])
+		expect(date[0][:test_data]).to eq("80")
+
+		date = Timetwister.parse("1777 Spring - 1778 Summer")
+		expect(date[0][:date_start]).to eq("1777-03-20")
+		expect(date[0][:date_start_full]).to eq("1777-03-20")
+		expect(date[0][:date_end]).to eq("1778-09-23")
+		expect(date[0][:date_end_full]).to eq("1778-09-23")
+		expect(date[0][:inclusive_range]).to eq(true)
+		expect(date[0][:index_dates]).to eq([1777, 1778])
+		expect(date[0][:test_data]).to eq("80")
 	end
 
 	it "parses dates with punctuation" do


### PR DESCRIPTION
As requested by @charmingduchess, this implements support for season ranges (e.g. `Spring 2000 - Summer 2002`), along with support for abbreviated seasons (e.g. `win. 2000`)