### PR TITLE
error handling for datetime parse failures

### DIFF
--- a/lib/timetwister/parser.rb
+++ b/lib/timetwister/parser.rb
@@ -60,7 +60,10 @@ class Parser
 						# using a begin/rescue to catch dates that Date.parse errors on
 						begin
 							c[:proc].call(work_string, c[:arg])
-						rescue Date::Error
+
+						# ArgumentError for pre-2.7.0 DateTime errors,
+						# Date::Error for 2.7.0 and later
+						rescue ArgumentError || Date::Error
 							@dates = { :original_string => @string, :index_dates => [], :keydate => nil, :keydate_z => nil, :date_start => nil, :date_end => nil,
 									:date_start_full => nil, :date_end_full => nil, :inclusive_range => nil, :certainty => nil }
 						end

--- a/lib/timetwister/parser.rb
+++ b/lib/timetwister/parser.rb
@@ -56,7 +56,14 @@ class Parser
 					if c[:proc]
 						# clone string to avoid changing it via in-place methods used in Procs
 						work_string = @string.clone
-						c[:proc].call(work_string, c[:arg])
+
+						# using a begin/rescue to catch dates that Date.parse errors on
+						begin
+							c[:proc].call(work_string, c[:arg])
+						rescue Date::Error
+							@dates = { :original_string => @string, :index_dates => [], :keydate => nil, :keydate_z => nil, :date_start => nil, :date_end => nil,
+									:date_start_full => nil, :date_end_full => nil, :inclusive_range => nil, :certainty => nil }
+						end
 					end
 					break
 				end

--- a/lib/timetwister/version.rb
+++ b/lib/timetwister/version.rb
@@ -1,3 +1,3 @@
 module Timetwister
-  VERSION = "0.2.8"
+  VERSION = "0.2.9"
 end

--- a/spec/dates_spec.rb
+++ b/spec/dates_spec.rb
@@ -46,7 +46,6 @@ describe Timetwister do
 	end
 
 	it "parses ranges of full dates" do
-
 		forms = ["July 4 1776 - March 1 1789", "4 July 1776 - 1 March 1789", "1776 July 4 - 1789 March 1", "1776 4 July - 1789 1 March", "1776 4 July to 1789 1 March"]
 		forms.each do |f|
 			date = Timetwister.parse(f)
@@ -570,6 +569,62 @@ describe Timetwister do
 			expect(date[0][:index_dates]).to eq([])
 			expect(date[0][:test_data]).to eq(nil)
 		end
+	end
+
+	it "DOES NOT parse nonexistent dates" do
+		date = Timetwister.parse('1776 September 31')
+		expect(date[0][:date_start]).to eq(nil)
+		expect(date[0][:date_start_full]).to eq(nil)
+		expect(date[0][:date_end]).to eq(nil)
+		expect(date[0][:date_end_full]).to eq(nil)
+		expect(date[0][:inclusive_range]).to eq(nil)
+		expect(date[0][:index_dates]).to eq([])
+		expect(date[0][:test_data]).to eq(nil)
+
+		date = Timetwister.parse('1776-11-31')
+		expect(date[0][:date_start]).to eq(nil)
+		expect(date[0][:date_start_full]).to eq(nil)
+		expect(date[0][:date_end]).to eq(nil)
+		expect(date[0][:date_end_full]).to eq(nil)
+		expect(date[0][:inclusive_range]).to eq(nil)
+		expect(date[0][:index_dates]).to eq([])
+		expect(date[0][:test_data]).to eq(nil)
+
+		date = Timetwister.parse('1776-11-00')
+		expect(date[0][:date_start]).to eq(nil)
+		expect(date[0][:date_start_full]).to eq(nil)
+		expect(date[0][:date_end]).to eq(nil)
+		expect(date[0][:date_end_full]).to eq(nil)
+		expect(date[0][:inclusive_range]).to eq(nil)
+		expect(date[0][:index_dates]).to eq([])
+		expect(date[0][:test_data]).to eq(nil)
+
+		date = Timetwister.parse('1776 whatever 31')
+		expect(date[0][:date_start]).to eq(nil)
+		expect(date[0][:date_start_full]).to eq(nil)
+		expect(date[0][:date_end]).to eq(nil)
+		expect(date[0][:date_end_full]).to eq(nil)
+		expect(date[0][:inclusive_range]).to eq(nil)
+		expect(date[0][:index_dates]).to eq([])
+		expect(date[0][:test_data]).to eq(nil)
+
+		date = Timetwister.parse('1776 sometime 72 - december 42 1999')
+		expect(date[0][:date_start]).to eq(nil)
+		expect(date[0][:date_start_full]).to eq(nil)
+		expect(date[0][:date_end]).to eq(nil)
+		expect(date[0][:date_end_full]).to eq(nil)
+		expect(date[0][:inclusive_range]).to eq(nil)
+		expect(date[0][:index_dates]).to eq([])
+		expect(date[0][:test_data]).to eq(nil)
+
+		date = Timetwister.parse('just absolute garbage')
+		expect(date[0][:date_start]).to eq(nil)
+		expect(date[0][:date_start_full]).to eq(nil)
+		expect(date[0][:date_end]).to eq(nil)
+		expect(date[0][:date_end_full]).to eq(nil)
+		expect(date[0][:inclusive_range]).to eq(nil)
+		expect(date[0][:index_dates]).to eq([])
+		expect(date[0][:test_data]).to eq(nil)
 	end
 
 	it "parses lists of years" do


### PR DESCRIPTION
When `Date.parse()` is handed an invalid date, it throws an error, which gets passed up through Timetwister and out to whatever was expecting a result.  This PR incorporates error handling for `Date::Error`, which will return a proper hash with an unparsed string in it (as anticipated by the library's behavior).